### PR TITLE
Reduced number of notifications for aggregate task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test:
 	pipenv run python -m unittest discover -s backtester/test
 
 test_scraper:
-	pipenv run python -m unittest discover -s data_scraper
+	pipenv run python -m pytest -v data_scraper
 
 scrape:
 ifdef scraper

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ To use the data scraper the following environment variables need to be set:
 - `$S3_BUCKET`: name of the S3 bucket to backup data
 - `$AWS_ACCESS_KEY_ID`: AWS acces key id
 - `$AWS_SECRET_ACCESS_KEY`: AWS secret key
+- `$SLACK_WEBHOOK`: used to send Slack notifications 
 
 You can configure the data scraper by editing the configuration file `data_scraper.conf` (json-formated).  
 
@@ -36,9 +37,6 @@ Sample file:
 {
   "cboe": {
     "mute_notifications": ["BFB", "CBSA"]
-  },
-  "notifications": {
-      "slack_webhook": "https://hooks.slack.com/services/MY_WORKSPACE_WEBHOOK"
   }
 }
 ```

--- a/docker/data_scraper/crontab
+++ b/docker/data_scraper/crontab
@@ -1,4 +1,4 @@
 0 19 * * 1-5 root cd /finance && run-task make scrape scraper=cboe
 0 19 * * 1-5 root cd /finance && run-task make scrape scraper=tiingo
-0 0 1 * * root cd /finance && run-task make aggregate && run-task make backup
+0 0 1 * * root cd /finance && run-task make aggregate; run-task make backup
 


### PR DESCRIPTION
Now scraper sends only one notification for the total number of symbols failed.